### PR TITLE
chore: 内部草稿-整理 deps.rs badge style 方案

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,7 +207,7 @@ dependencies = [
  "futures-util",
  "http 0.2.12",
  "impl-more",
- "itertools",
+ "itertools 0.14.0",
  "local-channel",
  "mime",
  "pin-project-lite",
@@ -337,9 +337,11 @@ name = "badge"
 version = "0.2.0"
 dependencies = [
  "base64",
+ "pretty_assertions",
  "rusttype",
  "serde",
  "serde_urlencoded",
+ "xml_c14n",
 ]
 
 [[package]]
@@ -347,6 +349,24 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+]
 
 [[package]]
 name = "bitflags"
@@ -447,6 +467,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -468,6 +497,17 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -723,6 +763,12 @@ dependencies = [
  "syn",
  "unicode-xid",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -2231,6 +2277,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "grass"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2682,6 +2734,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -2821,6 +2882,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2829,6 +2900,18 @@ dependencies = [
  "bitflags",
  "libc",
  "redox_syscall 0.7.1",
+]
+
+[[package]]
+name = "libxml"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74a5e46b8bcd6b70cb485ca086e43aa020af841e29fb0aba88ce02cd1cb52cc7"
+dependencies = [
+ "bindgen",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2951,6 +3034,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2970,6 +3059,16 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -3152,6 +3251,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
 ]
 
 [[package]]
@@ -4545,6 +4654,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5129,6 +5244,22 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "xml_c14n"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10920b2d5910f5e249f6476ae61952fe3f0b9d1fdf379a994a4325984e63665c"
+dependencies = [
+ "libxml",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/libs/badge/Cargo.toml
+++ b/libs/badge/Cargo.toml
@@ -17,4 +17,6 @@ rusttype = "0.9"
 serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
+pretty_assertions = "1"
 serde_urlencoded = "0.7"
+xml_c14n = "0.3"

--- a/libs/badge/tests/badge_maker_fixtures.rs
+++ b/libs/badge/tests/badge_maker_fixtures.rs
@@ -1,0 +1,67 @@
+use badge::{Badge, BadgeOptions, BadgeStyle};
+use serde::Deserialize;
+
+/// These tests intentionally compare our generated SVG against upstream badge-maker fixtures.
+///
+/// Fixture source is documented in `tests/fixtures/README.md`.
+///
+/// Note: some cases are expected to fail until style support and rendering parity are implemented.
+#[derive(Debug, Deserialize)]
+struct StyleQuery {
+    style: BadgeStyle,
+}
+
+fn normalize_svg(input: &str) -> String {
+    input.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn assert_fixture_parity(style_query: &str, fixture_file: &str) {
+    let style = serde_urlencoded::from_str::<StyleQuery>(style_query)
+        .map(|query| query.style)
+        .unwrap_or_else(|err| {
+            panic!(
+                "style parsing is not supported yet for `{style_query}`: {err}. \
+This test exists as a TODO parity target against badge-maker fixtures."
+            )
+        });
+
+    let badge = Badge::new(BadgeOptions {
+        subject: "cactus".to_owned(),
+        status: "grown".to_owned(),
+        color: "#b3e".to_owned(),
+        style,
+    });
+
+    let expected = std::fs::read_to_string(format!(
+        "{}/tests/fixtures/{fixture_file}",
+        env!("CARGO_MANIFEST_DIR")
+    ))
+    .unwrap_or_else(|err| panic!("failed to read fixture `{fixture_file}`: {err}"));
+
+    assert_eq!(normalize_svg(&badge.to_svg()), normalize_svg(&expected));
+}
+
+#[test]
+fn fixture_flat_message_label_no_logo() {
+    assert_fixture_parity("style=flat", "flat.cactus-grown.svg");
+}
+
+#[test]
+fn fixture_flat_square_message_label_no_logo() {
+    assert_fixture_parity("style=flat-square", "flat-square.cactus-grown.svg");
+}
+
+#[test]
+fn fixture_plastic_message_label_no_logo() {
+    assert_fixture_parity("style=plastic", "plastic.cactus-grown.svg");
+}
+
+#[test]
+fn fixture_for_the_badge_message_label_no_logo() {
+    assert_fixture_parity("style=for-the-badge", "for-the-badge.cactus-grown.svg");
+}
+
+#[test]
+fn fixture_social_message_label_no_logo() {
+    assert_fixture_parity("style=social", "social.cactus-grown.svg");
+}

--- a/libs/badge/tests/badge_maker_fixtures.rs
+++ b/libs/badge/tests/badge_maker_fixtures.rs
@@ -22,7 +22,7 @@ fn canonicalize(svg: &str, context: &str) -> String {
             inclusive_ns_prefixes: vec![],
         },
     )
-    .expect(context)
+    .unwrap_or_else(|err| panic!("failed to canonicalize {context}: {err}"))
 }
 
 fn assert_fixture_parity(style_query: &str, fixture_file: &str) {

--- a/libs/badge/tests/fixtures/README.md
+++ b/libs/badge/tests/fixtures/README.md
@@ -1,0 +1,18 @@
+# Fixture source
+
+These SVG fixtures come from the upstream `badge-maker` snapshot tests in `badges/shields`.
+
+- Source snapshot file: [__snapshots__/make-badge.spec.js](https://github.com/badges/shields/blob/master/__snapshots__/make-badge.spec.js)
+- Source test definitions: [badge-maker/lib/make-badge.spec.js](https://github.com/badges/shields/blob/master/badge-maker/lib/make-badge.spec.js)
+
+Extraction notes:
+
+- Extracted from the snapshot entries named:
+  - `"flat" template ... message/label, no logo`
+  - `"flat-square" template ... message/label, no logo`
+  - `"plastic" template ... message/label, no logo`
+  - `"for-the-badge" template ... message/label, no logo`
+  - `"social" template ... message/label, no logo`
+- Input case represented by those entries is `label=cactus`, `message=grown`, `color=#b3e`, `labelColor=#0f0`.
+- This fixture set is intentionally used as a parity target for deps.rs `libs/badge`.
+- Some tests are expected to fail until unsupported styles and rendering differences are implemented.

--- a/libs/badge/tests/fixtures/flat-square.cactus-grown.svg
+++ b/libs/badge/tests/fixtures/flat-square.cactus-grown.svg
@@ -1,0 +1,28 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="90"
+  height="20"
+  role="img"
+  aria-label="cactus: grown"
+>
+  <title>cactus: grown</title>
+  <g shape-rendering="crispEdges">
+    <rect width="45" height="20" fill="#0f0" />
+    <rect x="45" width="45" height="20" fill="#b3e" />
+  </g>
+  <g
+    fill="#fff"
+    text-anchor="middle"
+    font-family="Verdana,Geneva,DejaVu Sans,sans-serif"
+    text-rendering="geometricPrecision"
+    font-size="110"
+  >
+    <text x="235" y="140" transform="scale(.1)" fill="#fff" textLength="350">
+      cactus
+    </text>
+    <text x="665" y="140" transform="scale(.1)" fill="#fff" textLength="350">
+      grown
+    </text>
+  </g>
+</svg>
+

--- a/libs/badge/tests/fixtures/flat.cactus-grown.svg
+++ b/libs/badge/tests/fixtures/flat.cactus-grown.svg
@@ -1,0 +1,56 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="90"
+  height="20"
+  role="img"
+  aria-label="cactus: grown"
+>
+  <title>cactus: grown</title>
+  <linearGradient id="s" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1" />
+    <stop offset="1" stop-opacity=".1" />
+  </linearGradient>
+  <clipPath id="r"><rect width="90" height="20" rx="3" fill="#fff" /></clipPath>
+  <g clip-path="url(#r)">
+    <rect width="45" height="20" fill="#0f0" />
+    <rect x="45" width="45" height="20" fill="#b3e" />
+    <rect width="90" height="20" fill="url(#s)" />
+  </g>
+  <g
+    fill="#fff"
+    text-anchor="middle"
+    font-family="Verdana,Geneva,DejaVu Sans,sans-serif"
+    text-rendering="geometricPrecision"
+    font-size="110"
+  >
+    <text
+      aria-hidden="true"
+      x="235"
+      y="150"
+      fill="#010101"
+      fill-opacity=".3"
+      transform="scale(.1)"
+      textLength="350"
+    >
+      cactus
+    </text>
+    <text x="235" y="140" transform="scale(.1)" fill="#fff" textLength="350">
+      cactus
+    </text>
+    <text
+      aria-hidden="true"
+      x="665"
+      y="150"
+      fill="#010101"
+      fill-opacity=".3"
+      transform="scale(.1)"
+      textLength="350"
+    >
+      grown
+    </text>
+    <text x="665" y="140" transform="scale(.1)" fill="#fff" textLength="350">
+      grown
+    </text>
+  </g>
+</svg>
+

--- a/libs/badge/tests/fixtures/for-the-badge.cactus-grown.svg
+++ b/libs/badge/tests/fixtures/for-the-badge.cactus-grown.svg
@@ -1,0 +1,35 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="146.75"
+  height="28"
+  role="img"
+  aria-label="CACTUS: GROWN"
+>
+  <title>CACTUS: GROWN</title>
+  <g shape-rendering="crispEdges">
+    <rect width="72.5" height="28" fill="#0f0" />
+    <rect x="72.5" width="74.25" height="28" fill="#b3e" />
+  </g>
+  <g
+    fill="#fff"
+    text-anchor="middle"
+    font-family="Verdana,Geneva,DejaVu Sans,sans-serif"
+    text-rendering="geometricPrecision"
+    font-size="100"
+  >
+    <text transform="scale(.1)" x="362.5" y="175" textLength="485" fill="#fff">
+      CACTUS
+    </text>
+    <text
+      transform="scale(.1)"
+      x="1096.25"
+      y="175"
+      textLength="502.5"
+      fill="#fff"
+      font-weight="bold"
+    >
+      GROWN
+    </text>
+  </g>
+</svg>
+

--- a/libs/badge/tests/fixtures/plastic.cactus-grown.svg
+++ b/libs/badge/tests/fixtures/plastic.cactus-grown.svg
@@ -1,0 +1,58 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="90"
+  height="18"
+  role="img"
+  aria-label="cactus: grown"
+>
+  <title>cactus: grown</title>
+  <linearGradient id="s" x2="0" y2="100%">
+    <stop offset="0" stop-color="#fff" stop-opacity=".7" />
+    <stop offset=".1" stop-color="#aaa" stop-opacity=".1" />
+    <stop offset=".9" stop-color="#000" stop-opacity=".3" />
+    <stop offset="1" stop-color="#000" stop-opacity=".5" />
+  </linearGradient>
+  <clipPath id="r"><rect width="90" height="18" rx="4" fill="#fff" /></clipPath>
+  <g clip-path="url(#r)">
+    <rect width="45" height="18" fill="#0f0" />
+    <rect x="45" width="45" height="18" fill="#b3e" />
+    <rect width="90" height="18" fill="url(#s)" />
+  </g>
+  <g
+    fill="#fff"
+    text-anchor="middle"
+    font-family="Verdana,Geneva,DejaVu Sans,sans-serif"
+    text-rendering="geometricPrecision"
+    font-size="110"
+  >
+    <text
+      aria-hidden="true"
+      x="235"
+      y="140"
+      fill="#010101"
+      fill-opacity=".3"
+      transform="scale(.1)"
+      textLength="350"
+    >
+      cactus
+    </text>
+    <text x="235" y="130" transform="scale(.1)" fill="#fff" textLength="350">
+      cactus
+    </text>
+    <text
+      aria-hidden="true"
+      x="665"
+      y="140"
+      fill="#010101"
+      fill-opacity=".3"
+      transform="scale(.1)"
+      textLength="350"
+    >
+      grown
+    </text>
+    <text x="665" y="130" transform="scale(.1)" fill="#fff" textLength="350">
+      grown
+    </text>
+  </g>
+</svg>
+

--- a/libs/badge/tests/fixtures/social.cactus-grown.svg
+++ b/libs/badge/tests/fixtures/social.cactus-grown.svg
@@ -1,0 +1,86 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="95"
+  height="20"
+  role="img"
+  aria-label="Cactus: grown"
+>
+  <title>Cactus: grown</title>
+  <style>
+    a:hover #llink {
+      fill: url(#b);
+      stroke: #ccc;
+    }
+    a:hover #rlink {
+      fill: #4183c4;
+    }
+  </style>
+  <linearGradient id="a" x2="0" y2="100%">
+    <stop offset="0" stop-color="#fcfcfc" stop-opacity="0" />
+    <stop offset="1" stop-opacity=".1" />
+  </linearGradient>
+  <linearGradient id="b" x2="0" y2="100%">
+    <stop offset="0" stop-color="#ccc" stop-opacity=".1" />
+    <stop offset="1" stop-opacity=".1" />
+  </linearGradient>
+  <g stroke="#d5d5d5">
+    <rect
+      stroke="none"
+      fill="#fcfcfc"
+      x="0.5"
+      y="0.5"
+      width="47"
+      height="19"
+      rx="2"
+    />
+    <rect x="53.5" y="0.5" width="41" height="19" rx="2" fill="#fafafa" />
+    <rect x="53" y="7.5" width="0.5" height="5" stroke="#fafafa" />
+    <path d="M53.5 6.5 l-3 3v1 l3 3" fill="#fafafa" />
+  </g>
+  <g
+    aria-hidden="true"
+    fill="#333"
+    text-anchor="middle"
+    font-family="Helvetica Neue,Helvetica,Arial,sans-serif"
+    text-rendering="geometricPrecision"
+    font-weight="700"
+    font-size="110px"
+    line-height="14px"
+  >
+    <rect
+      id="llink"
+      stroke="#d5d5d5"
+      fill="url(#a)"
+      x=".5"
+      y=".5"
+      width="47"
+      height="19"
+      rx="2"
+    />
+    <text
+      aria-hidden="true"
+      x="235"
+      y="150"
+      fill="#fff"
+      transform="scale(.1)"
+      textLength="370"
+    >
+      Cactus
+    </text>
+    <text x="235" y="140" transform="scale(.1)" textLength="370">Cactus</text>
+    <text
+      aria-hidden="true"
+      x="735"
+      y="150"
+      fill="#fff"
+      transform="scale(.1)"
+      textLength="330"
+    >
+      grown
+    </text>
+    <text id="rlink" x="735" y="140" transform="scale(.1)" textLength="330">
+      grown
+    </text>
+  </g>
+</svg>
+


### PR DESCRIPTION
## 目的
用于内部评审 deps.rs badge style（含原生 `status.svg` 与 shields endpoint 方案）的实现方向与验收口径。

## 相关 issue
- [deps-rs/deps.rs#245](https://github.com/deps-rs/deps.rs/issues/245)

## 阶段一计划（已确认）
目标：参考 shields 的 `badge-maker` snapshot 测试，复用其 fixture，确保我们独立的 badge 生成库在核心场景下与 `badge-maker` 风格一致。

- 对齐范围（阶段一）
  - style：`flat` / `flat-square` / `plastic` / `for-the-badge` / `social`
  - 场景：`label + message` 的核心组合（先不引入复杂 logo/links）
- 测试策略
  - 复用 `badge-maker` fixture 作为上游金标
  - 本地生成 SVG 后做规范化（避免无意义空白/格式差异）再进行快照对比
  - 在 CI 中自动执行，作为回归保护
- 交付物
  - fixtures（上游金标）
  - parity 测试（本地渲染 vs fixture）
  - CI workflow（PR 自动校验）
- 参考资料
  - [badge-maker 测试文件](https://github.com/badges/shields/blob/master/badge-maker/lib/make-badge.spec.js)
  - [badge-maker 快照文件](https://github.com/badges/shields/blob/master/__snapshots__/make-badge.spec.js)

## 预览 URL（直接点开可看）
- 原生（当前支持）
  - [default flat](https://deps.rs/crate/syn/2.0.115/status.svg)
  - [flat-square](https://deps.rs/crate/syn/2.0.115/status.svg?style=flat-square)
  - [for-the-badge](https://deps.rs/crate/syn/2.0.115/status.svg?style=for-the-badge)
- 原生文案参数
  - [compact=true](https://deps.rs/crate/syn/2.0.115/status.svg?compact=true)
  - [subject=syn deps](https://deps.rs/crate/syn/2.0.115/status.svg?subject=syn%20deps)
- shields endpoint（用于 plastic/social 等）
  - [shield.json 数据源](https://deps.rs/crate/syn/2.0.115/shield.json)
  - [shields plastic](https://img.shields.io/endpoint?url=https%3A%2F%2Fdeps.rs%2Fcrate%2Fsyn%2F2.0.115%2Fshield.json&style=plastic)
  - [shields social](https://img.shields.io/endpoint?url=https%3A%2F%2Fdeps.rs%2Fcrate%2Fsyn%2F2.0.115%2Fshield.json&style=social)

## 当前顾虑（先记录，后续再推进）
- 要达到与 shields `badge-maker` 的高一致性，需要对 `libs/badge` 做结构性重构（输入模型、宽度算法、SVG 模板、各 style renderer），改动面较大。
- 一次性大改会提高 review 与回归成本，不利于维护者快速确认风险边界。
- 当前 PR 先保留 fixture parity 与 XML 级对比能力，作为后续分阶段开发的基线；具体功能对齐改动暂缓。
- 后续建议按 style 分阶段推进（先 `flat`，再其它 style），每阶段独立验证并收敛 diff。

## 备注
这是内部开发草稿 PR，不是提交给上游 `deps-rs/deps.rs` 的 PR。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
- Added comprehensive validation tests for badge SVG output against upstream badge-maker fixtures to ensure consistent rendering across all badge style variants: flat, flat-square, plastic, for-the-badge, and social.
- Implemented enhanced comparison mechanisms for reliable test fixture validation across different badge configurations.
- Added documentation for test fixtures and validation procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->